### PR TITLE
Dockerfile maven - Parameterize microservice's JAR file name. Upgrade Spotify Dockerfile's maven plugin version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,6 @@ env:
   - TMX_DOCKER_IMAGE=johncarnell/tmx-simple-service:chapter1
 script:
 - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-- mvn clean package docker:build
+- mvn clean package
 - docker push $TMX_DOCKER_IMAGE
 - ecs-cli --version

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To build the code examples for Chapter 1 as a docker image, open a command-line 
 
 Run the following maven command.  This command will execute the [Spotify docker plugin](https://github.com/spotify/docker-maven-plugin) defined in the pom.xml file.  
 
-   **mvn clean package docker:build**
+   **mvn clean package**
 
 If everything builds successfully you should see a message indicating that the build was successful.
 

--- a/simpleservice/Dockerfile
+++ b/simpleservice/Dockerfile
@@ -2,7 +2,8 @@ FROM openjdk:8-jdk-alpine
 RUN  apk update && apk upgrade && apk add netcat-openbsd
 RUN mkdir -p /usr/local/simple-service
 
-ADD target/simple-service-0.0.1-SNAPSHOT.jar /usr/local/simple-service
+ARG JAR_FILE
+ADD target/${JAR_FILE} /usr/local/simple-service
 ADD src/main/docker/run.sh run.sh
 RUN chmod +x run.sh
 CMD ./run.sh

--- a/simpleservice/pom.xml
+++ b/simpleservice/pom.xml
@@ -42,7 +42,7 @@
       <plugin>
         <groupId>com.spotify</groupId>
         <artifactId>dockerfile-maven-plugin</artifactId>
-        <version>1.3.4</version>
+        <version>1.3.7</version>
         <executions>
           <execution>
             <id>default</id>
@@ -59,6 +59,9 @@
             <configuration>
               <repository>${docker.image.name}</repository>
               <tag>${docker.image.tag}</tag>
+              <buildArgs>
+                <JAR_FILE>${project.build.finalName}.jar</JAR_FILE>
+              </buildArgs>              
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
Change to remove the harcoded microservice's JAR file name from docker build process for Spotify Dockerfile maven plugin, and set up as the projects build name. Also, version upgrade of Dockerfile maven plugin dependency.