### PR TITLE
use version 1.0.0 of docker-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
       <plugin>
         <groupId>com.spotify</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.4.10</version>
+        <version>1.0.0</version>
         <configuration>
         <baseImage>java</baseImage>
         <imageName>example</imageName>

--- a/simpleservice/pom.xml
+++ b/simpleservice/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>com.spotify</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.4.10</version>
+        <version>1.0.0</version>
         <configuration>
           <imageName>${docker.image.name}:${docker.image.tag}</imageName>
           <dockerDirectory>${basedir}/target/dockerfile</dockerDirectory>


### PR DESCRIPTION
When trying to build I got the following error

```
Failed to execute goal com.spotify:docker-maven-plugin:0.4.10:build (default-cli) on project simple-service: Exception caught: java.util.concurrent.ExecutionException: com.spotify.docker.client.shaded.javax.ws.rs.ProcessingException: java.lang.UnsatisfiedLinkError: could not load FFI provider jnr.ffi.provider.jffi.Provider: ExceptionInInitializerError: Can't overwrite cause with java.lang.UnsatisfiedLinkError: java.lang.UnsatisfiedLinkError: Can't load library: /var/folders/gz/n_zqz9y55m335zt2lk1t942m0000gn/T/jffi18211211055850975176.dylib
[ERROR] 	at java.base/java.lang.C
```

Following to [this answer](https://stackoverflow.com/a/47484485/5565834), changing the version to `1.0.0` fixed the problem.